### PR TITLE
Start the match timer after the players have received the IP address

### DIFF
--- a/src/main/java/de/gost0r/pickupbot/pickup/Match.java
+++ b/src/main/java/de/gost0r/pickupbot/pickup/Match.java
@@ -686,7 +686,6 @@ public class Match implements Runnable {
 
     // DONT CALL THIS OUTSIDE OF launch() !!!
     public void run() {
-        startTime = System.currentTimeMillis();
         gtvServer = logic.setupGTV();
         Random rand = new Random();
 
@@ -841,6 +840,9 @@ public class Match implements Runnable {
                 logic.bot.sendMsg(player.getDiscordUser(), msg_t);
             }
         }
+
+        // Start the timer AFTER players have received the server IP
+        startTime = System.currentTimeMillis();
 
         msg = Config.pkup_go_pub_sent;
         msg = msg.replace(".gametype.", gametype.getName());


### PR DESCRIPTION
Players were getting banned due to short connect time when server spawn took longer than normal